### PR TITLE
Allow for empty strings for the source to not crash

### DIFF
--- a/IconApp/IconApp.Droid/Renderers/IconViewRenderer.cs
+++ b/IconApp/IconApp.Droid/Renderers/IconViewRenderer.cs
@@ -56,7 +56,7 @@ namespace IconApp.Droid.Renderers
 
         private void UpdateBitmap(IconView previous = null)
         {
-            if (!_isDisposed)
+            if (!_isDisposed && !string.IsNullOrWhiteSpace(Element.Source))
             {
                 var d = Resources.GetDrawable(Element.Source).Mutate();
                 d.SetColorFilter(new LightingColorFilter(Element.Foreground.ToAndroid(), Element.Foreground.ToAndroid()));

--- a/IconApp/IconApp.iOS/Renderer/IconViewRenderer.cs
+++ b/IconApp/IconApp.iOS/Renderer/IconViewRenderer.cs
@@ -70,7 +70,7 @@ namespace IconApp.iOS.Renderers
 
         private void SetImage(IconView previous = null)
         {
-            if (previous == null)
+            if (previous == null && !string.IsNullOrWhiteSpace(Element.Source))
             {
                 var uiImage = new UIImage(Element.Source);
                 uiImage = uiImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);


### PR DESCRIPTION
Allows for the Icon source to be a bindable property. Would throw exceptions when trying to load the icon when there is not an Icon source set.