### PR TITLE
Updated renderer to not use obsolet GetDrawable

### DIFF
--- a/IconApp/IconApp.Droid/Renderers/IconViewRenderer.cs
+++ b/IconApp/IconApp.Droid/Renderers/IconViewRenderer.cs
@@ -58,7 +58,7 @@ namespace IconApp.Droid.Renderers
         {
             if (!_isDisposed && !string.IsNullOrWhiteSpace(Element.Source))
             {
-                var d = Resources.GetDrawable(Element.Source).Mutate();
+                var d = Context.GetDrawable(Element.Source).Mutate();
                 d.SetColorFilter(new LightingColorFilter(Element.Foreground.ToAndroid(), Element.Foreground.ToAndroid()));
                 d.Alpha = Element.Foreground.ToAndroid().A;
                 Control.SetImageDrawable(d);


### PR DESCRIPTION
This update changes the using of obsolet Resources.GetDrawable for Context.GetDrawable